### PR TITLE
Addressing in Dockerfile the usage of HTTPS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk --no-cache update && apk --no-cache upgrade && apk --update --no-cache -
         *)      _arch="$ARCH"   ;; \
     esac && \
     cd /tmp && \
-    curl -sSL https://install.speedtest.net/app/cli/ookla-speedtest-${VERSION}-linux-${_arch}.tgz | tar xz && \
+    curl --proto "=https" --tlsv1.2 -sSf -L https://install.speedtest.net/app/cli/ookla-speedtest-${VERSION}-linux-${_arch}.tgz | tar xz && \
     mv /tmp/speedtest /usr/local/bin/ && \
     rm -rf /tmp/speedtest.* && \
     speedtest --accept-license --accept-gdpr && \


### PR DESCRIPTION
Not enforcing HTTPS here might allow for redirections to insecure websites. 