### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Check Alpine Linux updates
         id: check-image
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.force_build == 'false')
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (inputs.force_build == 'false' || inputs.update_digest == 'true'))
         run: |
           echo "🔍 Checking Alpine Linux for updates..."
           


### PR DESCRIPTION
The check-image step will now run when:

- Scheduled runs : Always runs to check for Alpine updates
- Manual runs : Runs when either:
  - force_build is false (existing behavior)
  - update_digest is true (new behavior)
This ensures that when you manually trigger the workflow with the "Update base image digests after manual build" checkbox enabled, the system will:

1. 1.
   Check the current Alpine digest
2. 2.
   Make it available to the update-digest job
3. 3.
   Allow the digest update to proceed successfully