### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -456,7 +456,7 @@ jobs:
           update_digest "ALPINE_DIGEST" "${{ vars.ALPINE_DIGEST }}" "${{ needs.check-base-image.outputs.alpine_digest }}"
           update_digest "UBUNTU_DIGEST" "${{ vars.UBUNTU_DIGEST }}" "${{ needs.check-base-image.outputs.ubuntu_digest }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
 
   # NEW: Build Summary
   build-summary:


### PR DESCRIPTION
Updates a repository variable that you can reference in a GitHub Actions workflow.
Authenticated users must have collaborator access to a repository to create, update, or read variables.
OAuth app tokens and personal access tokens (classic) need the repo scope to use this endpoint.
Fine-grained access tokens for "Update a repository variable"
This endpoint works with the following fine-grained token types:
* GitHub App user access tokens
* GitHub App installation access tokens
* Fine-grained personal access tokens
The fine-grained token must have the following permission set:
* "Variables" repository permissions (write)