### PR TITLE
Exclude Dependabot from SonarQube analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,8 +188,10 @@ jobs:
     name: SonarQube Analysis
     runs-on: ubuntu-latest
     if: >
-      (github.event_name == 'push' || github.event_name == 'pull_request') ||
-      (github.event_name == 'schedule' && needs.check-base-image.outputs.should_build == 'true')
+      github.actor != 'dependabot[bot]' && (
+        (github.event_name == 'push' || github.event_name == 'pull_request') ||
+        (github.event_name == 'schedule' && needs.check-base-image.outputs.should_build == 'true')
+      )
     needs: [check-base-image]
     steps:
       - name: Checkout


### PR DESCRIPTION
Prevent Dependabot from triggering SonarQube analysis during push, pull request, or scheduled events.