### PR TITLE
Add syft to PATH after installation in security scan job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -527,7 +527,10 @@ jobs:
       # OSV-Scanner for app dependencies
       ######################
       - name: Install Syft (SBOM generator)
-        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh
+          # Add syft to PATH for subsequent steps
+          echo "$PWD/bin" >> $GITHUB_PATH
 
       - name: Generate SBOM
         run: syft ${{ env.REGISTRY_IMAGE }}:latest -o json > sbom.json


### PR DESCRIPTION
Ensure syft is added to the PATH after installation, allowing subsequent steps to access it without issues.