### PR TITLE
Add security-events permission for SARIF uploads in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ permissions:
   contents: write  # Required for updating variables
   packages: write
   actions: write   # Required for updating repository variables
+  security-events: write  # Required for uploading SARIF results to GitHub Security
 
 on:
   workflow_dispatch:

--- a/repository-security-checklist.md
+++ b/repository-security-checklist.md
@@ -298,11 +298,20 @@ security-scan:
     
     # Upload SARIF results to GitHub Security
     - name: Upload Trivy SARIF to GitHub Security
-      uses: github/codeql-action/upload-sarif@v3.27.0
+      uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0
       if: always()
       with:
         sarif_file: trivy-results.sarif
         category: trivy-container-scan
+
+**Important**: Ensure your workflow has the required permissions for SARIF upload:
+```yaml
+permissions:
+  contents: write
+  packages: write
+  actions: write
+  security-events: write  # Required for uploading SARIF results to GitHub Security
+```
 ```
 
 ##### Enhanced Trivy Setup Benefits:


### PR DESCRIPTION
Include the `security-events` permission in workflows to enable uploading SARIF results to GitHub Security. Update documentation to highlight the required permissions for successful uploads.