### PR TITLE
ci: update reusable workflow references to latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
   # Non-PR builds and publishes
   build-and-publish:
     if: github.event_name != 'pull_request'
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@28d0ede2a63ee4c4d47ea15eb66fdfc6b9926cb3
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@442c07e0fbad1bce2ad7ad1a335d240c7cd7892e
     permissions:
       contents: write
       packages: write
@@ -142,7 +142,7 @@ jobs:
   # PR validation for regular users (with SonarQube)
   pr-validate:
     if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@28d0ede2a63ee4c4d47ea15eb66fdfc6b9926cb3
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@442c07e0fbad1bce2ad7ad1a335d240c7cd7892e
     with:
       image_name: speedtest-ookla
       arch_list: linux/amd64,linux/arm64                      # faster validation set; adjust if you need full matrix
@@ -163,7 +163,7 @@ jobs:
   # Dummy PR validation for Dependabot (no SonarQube)
   pr-validate-dependabot:
     if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@28d0ede2a63ee4c4d47ea15eb66fdfc6b9926cb3
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@442c07e0fbad1bce2ad7ad1a335d240c7cd7892e
     with:
       image_name: speedtest-ookla
       arch_list: linux/amd64

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   call-reusable:
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/create-release.yml@f575e5558b8140825508493151a4538d0fc51aeb
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/create-release.yml@442c07e0fbad1bce2ad7ad1a335d240c7cd7892e
     with:
       tag: ${{ inputs.tag }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -10,6 +10,8 @@ permissions:
 
 jobs:
   dependabot-review:
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/dependabot-reviewer.yml@f575e5558b8140825508493151a4538d0fc51aeb
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/dependabot-reviewer.yml@442c07e0fbad1bce2ad7ad1a335d240c7cd7892e
     with:
       auto_merge: true
+    secrets:
+      REPO_TOKEN: ${{ secrets.REPO_TOKEN }}  # 👈 pass your PAT here

--- a/.github/workflows/docker-scout.yml
+++ b/.github/workflows/docker-scout.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   scout-docker-image:
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/docker-scout.yml@f575e5558b8140825508493151a4538d0fc51aeb
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/docker-scout.yml@442c07e0fbad1bce2ad7ad1a335d240c7cd7892e
     with:
       image_name: lferrarotti74/speedtest-ookla
       compare_tag: latest

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   sync-main-to-dev:
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/sync-main-to-dev.yml@f575e5558b8140825508493151a4538d0fc51aeb
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/sync-main-to-dev.yml@442c07e0fbad1bce2ad7ad1a335d240c7cd7892e
     with:
       source_branch: main
       target_branch: dev


### PR DESCRIPTION
Update all GitHub Actions workflow files to reference the latest SHA of the reusable workflow templates. This ensures the latest fixes and improvements from the shared templates are utilized.

Also add missing REPO_TOKEN secret to the dependabot-reviewer workflow to enable proper authentication for automated merging.