### PR TITLE
ci: bump reusable GitHub workflow template references

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
   # Non-PR builds and publishes
   build-and-publish:
     if: github.event_name != 'pull_request'
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@f75177559730a570250f69b4740cad91cba38ccc
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@9e24159d0cbb549461b4e113aced93915096a490
     permissions:
       contents: write
       packages: write
@@ -142,7 +142,7 @@ jobs:
   # PR validation for regular users (with SonarQube)
   pr-validate:
     if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@f75177559730a570250f69b4740cad91cba38ccc
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@9e24159d0cbb549461b4e113aced93915096a490
     with:
       image_name: speedtest-ookla
       arch_list: linux/amd64,linux/arm64                      # faster validation set; adjust if you need full matrix
@@ -163,7 +163,7 @@ jobs:
   # Dummy PR validation for Dependabot (no SonarQube)
   pr-validate-dependabot:
     if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@f75177559730a570250f69b4740cad91cba38ccc
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@9e24159d0cbb549461b4e113aced93915096a490
     with:
       image_name: speedtest-ookla
       arch_list: linux/amd64

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   call-reusable:
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/create-release.yml@f75177559730a570250f69b4740cad91cba38ccc
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/create-release.yml@9e24159d0cbb549461b4e113aced93915096a490
     with:
       tag: ${{ inputs.tag }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dependabot-review:
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/dependabot-reviewer.yml@f75177559730a570250f69b4740cad91cba38ccc
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/dependabot-reviewer.yml@9e24159d0cbb549461b4e113aced93915096a490
     with:
       auto_merge: true
     secrets:

--- a/.github/workflows/docker-scout.yml
+++ b/.github/workflows/docker-scout.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   scout-docker-image:
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/docker-scout.yml@f75177559730a570250f69b4740cad91cba38ccc
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/docker-scout.yml@9e24159d0cbb549461b4e113aced93915096a490
     with:
       image_name: lferrarotti74/speedtest-ookla
       compare_tag: latest

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   sync-main-to-dev:
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/sync-main-to-dev.yml@f75177559730a570250f69b4740cad91cba38ccc
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/sync-main-to-dev.yml@9e24159d0cbb549461b4e113aced93915096a490
     with:
       source_branch: main
       target_branch: dev


### PR DESCRIPTION
update all referenced lferrarotti74/github-workflows-templates commit pins from f75177559730a570250f69b4740cad91cba38ccc to 9e24159d0cbb549461b4e113aced93915096a490 across all GitHub Actions workflow files