### PR TITLE
ci: update reusable workflow template commit hashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
   # Non-PR builds and publishes
   build-and-publish:
     if: github.event_name != 'pull_request'
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@e343334939c790054f182d3e9d8a7ae8085ecfe6
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@854e3b358ecf5e1ccc4dd42b19497d4cf2f63c88
     permissions:
       contents: write
       packages: write
@@ -142,7 +142,7 @@ jobs:
   # PR validation for regular users (with SonarQube)
   pr-validate:
     if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@e343334939c790054f182d3e9d8a7ae8085ecfe6
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@854e3b358ecf5e1ccc4dd42b19497d4cf2f63c88
     with:
       image_name: speedtest-ookla
       arch_list: linux/amd64,linux/arm64                      # faster validation set; adjust if you need full matrix
@@ -163,7 +163,7 @@ jobs:
   # Dummy PR validation for Dependabot (no SonarQube)
   pr-validate-dependabot:
     if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@e343334939c790054f182d3e9d8a7ae8085ecfe6
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/build-extended.yml@854e3b358ecf5e1ccc4dd42b19497d4cf2f63c88
     with:
       image_name: speedtest-ookla
       arch_list: linux/amd64

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   call-reusable:
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/create-release.yml@e343334939c790054f182d3e9d8a7ae8085ecfe6
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/create-release.yml@854e3b358ecf5e1ccc4dd42b19497d4cf2f63c88
     with:
       tag: ${{ inputs.tag }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dependabot-review:
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/dependabot-reviewer.yml@e343334939c790054f182d3e9d8a7ae8085ecfe6
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/dependabot-reviewer.yml@854e3b358ecf5e1ccc4dd42b19497d4cf2f63c88
     with:
       auto_merge: true
     secrets:

--- a/.github/workflows/docker-scout.yml
+++ b/.github/workflows/docker-scout.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   scout-docker-image:
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/docker-scout.yml@e343334939c790054f182d3e9d8a7ae8085ecfe6
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/docker-scout.yml@854e3b358ecf5e1ccc4dd42b19497d4cf2f63c88
     with:
       image_name: lferrarotti74/speedtest-ookla
       compare_tag: latest

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   sync-main-to-dev:
-    uses: lferrarotti74/github-workflows-templates/.github/workflows/sync-main-to-dev.yml@e343334939c790054f182d3e9d8a7ae8085ecfe6
+    uses: lferrarotti74/github-workflows-templates/.github/workflows/sync-main-to-dev.yml@854e3b358ecf5e1ccc4dd42b19497d4cf2f63c88
     with:
       source_branch: main
       target_branch: dev


### PR DESCRIPTION
## Summary
- Updated all reusable workflow template SHA references from `e343334939c790054f182d3e9d8a7ae8085ecfe6` to `854e3b358ecf5e1ccc4dd42b19497d4cf2f63c88`
- Affected workflows: `build.yml`, `create-release.yml`, `dependabot-reviewer.yml`, `docker-scout.yml`, `sync-main-to-dev.yml`
- Generated via `update-template-sha.sh` script

## Test plan
- [ ] Verify CI checks pass on this PR
- [ ] Confirm reusable workflows resolve correctly at the new SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)